### PR TITLE
Custom Backend Support Added

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,21 +1,22 @@
 import {
 	PUBLIC_NODE_ENV,
-	PUBLIC_API_ENDPOINT_PRODUCTION,
 	PUBLIC_FUSION_AUTH_API_KEY_PRODUCTION,
 	PUBLIC_FUSION_AUTH_APP_ID_PRODUCTION,
 	PUBLIC_FUSION_AUTH_BASE_URL_PRODUCTION,
-	PUBLIC_API_ENDPOINT_STAGING,
 	PUBLIC_FUSION_AUTH_API_KEY_STAGING,
 	PUBLIC_FUSION_AUTH_APP_ID_STAGING,
-	PUBLIC_FUSION_AUTH_BASE_URL_STAGING
+	PUBLIC_FUSION_AUTH_BASE_URL_STAGING,
 } from '$env/static/public';
+import { get } from 'svelte/store';
+import { backendConfig } from './stores/backend-config';
 
 export const APP_NAME = 'Splore';
 export const ENVIRONMENT = PUBLIC_NODE_ENV;
 
-export const WEBUI_HOSTNAME =
-	PUBLIC_NODE_ENV === 'production' ? PUBLIC_API_ENDPOINT_PRODUCTION : PUBLIC_API_ENDPOINT_STAGING;
-export const WEBUI_BASE_URL = `https://${WEBUI_HOSTNAME}`;
+export const WEBUI_BASE_URL = (() => {
+	const url = get(backendConfig).currentUrl;
+	return url.includes('localhost') ? `http://${url}` : `https://${url}`;
+})();
 export const WEBUI_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1`;
 
 export const OLLAMA_API_BASE_URL = `${WEBUI_BASE_URL}/ollama`;

--- a/src/lib/stores/backend-config.ts
+++ b/src/lib/stores/backend-config.ts
@@ -1,0 +1,49 @@
+import { writable, derived, type Readable } from 'svelte/store';
+import { 
+    PUBLIC_NODE_ENV, 
+    PUBLIC_API_ENDPOINT_PRODUCTION, 
+    PUBLIC_API_ENDPOINT_STAGING 
+} from '$env/static/public';
+
+// Store for custom backend URL
+const createCustomBackendStore = () => {
+    const key = 'custom-backend';
+    const initial = typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+    const store = writable<string | null>(initial);
+
+    // Subscribe to changes and update localStorage
+    if (typeof localStorage !== 'undefined') {
+        store.subscribe(value => {
+            if (value !== null) {
+                localStorage.setItem(key, value);
+            } else {
+                localStorage.removeItem(key);
+            }
+        });
+    }
+
+    return store;
+};
+
+// Create the stores
+export const customBackendUrl = createCustomBackendStore();
+
+// Derived store that returns the current backend URL
+export const backendConfig: Readable<{ currentUrl: string }> = derived(
+    [customBackendUrl],
+    ([$customBackendUrl]) => ({
+        currentUrl: $customBackendUrl || (PUBLIC_NODE_ENV === 'production' 
+            ? PUBLIC_API_ENDPOINT_PRODUCTION 
+            : PUBLIC_API_ENDPOINT_STAGING)
+    })
+);
+
+// Helper function to set custom backend URL
+export const setCustomBackendUrl = (url: string | null) => {
+    // Always remove existing value first
+    if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem('custom-backend');
+    }
+    // Then set the new value
+    customBackendUrl.set(url);
+}; 

--- a/src/lib/utils/backend-url.ts
+++ b/src/lib/utils/backend-url.ts
@@ -1,0 +1,25 @@
+import { setCustomBackendUrl } from '../stores/backend-config';
+
+/**
+ * Handles the backend URL parameter from the URL
+ * If 'backend' parameter is present, it will overwrite any existing custom backend URL
+ * If no parameter is present, it will use the environment default
+ */
+export function handleBackendUrlParam() {
+    if (typeof window === 'undefined') return;
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const backendParam = urlParams.get('backend');
+
+    // Always set the backend URL if parameter exists, overwriting any previous value
+    if (backendParam) {
+        setCustomBackendUrl(backendParam);
+
+        // Remove the backend parameter from URL without refreshing the page
+        urlParams.delete('backend');
+        const newUrl = window.location.pathname + 
+            (urlParams.toString() ? `?${urlParams.toString()}` : '') + 
+            window.location.hash;
+        window.history.replaceState({}, '', newUrl);
+    }
+} 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,7 +41,8 @@
 
 	import 'tippy.js/dist/tippy.css';
 
-	import { WEBUI_BASE_URL, WEBUI_HOSTNAME } from '$lib/constants';
+	import { WEBUI_BASE_URL } from '$lib/constants';
+	import { handleBackendUrlParam } from '$lib/utils/backend-url';
 	import i18n, { initI18n, getLanguages, changeLanguage } from '$lib/i18n';
 	import { bestMatchingLanguage } from '$lib/utils';
 	import { getAllTags, getChatList } from '$lib/apis/chats';
@@ -683,6 +684,9 @@
 			document.getElementById('splash-screen')?.remove();
 			loaded = true;
 		}
+
+		// Handle backend URL parameter if present
+		handleBackendUrlParam();
 
 		return () => {
 			window.removeEventListener('resize', onResize);


### PR DESCRIPTION
Added a custom backend support for backend engineers to test the app seamlessly.

User has to pass: backend url in the URL param to update the local storage.

Example usage: http://app.search.splore.st?backend=localhost:3000

Important:
Don't place http or https while setting up the backend url

Rest or Remove:
Remove `custom-backend` from localstorage, this will reset the backend url in the app and points to the environment deployed.